### PR TITLE
Server upgrade

### DIFF
--- a/autoload/rustplug.vim
+++ b/autoload/rustplug.vim
@@ -14,7 +14,7 @@ function! rustplug#logerr(message) abort
     "echoerr a:message
 endfunction
 
-function! rustplug#run(plugin) abort
+function! rustplug#runall(plugin) abort
 python3 << EOF
 """ Run all binaries in our rustplug directory. """
 import rustplug

--- a/autoload/rustplug.vim
+++ b/autoload/rustplug.vim
@@ -15,6 +15,24 @@ function! rustplug#logerr(message) abort
 endfunction
 
 function! rustplug#run(plugin) abort
+python3 << EOF
+""" Run all binaries in our rustplug directory. """
+import rustplug
+from rustplug import Environment
+from rustplug import Plugin
+
+
+rust_bin_dir: Path = Environment('').rust_bin_dir
+plugin_path: Path
+for plugin_path in rust_bin_dir.glob('*'):
+    env: Environment = Environment(plugin_path.name)
+    plugin: Plugin = env.plugin
+
+    plugin.run()
+EOF
+endfunction
+
+function! rustplug#run(plugin) abort
 
     " To keep it simple, keeping plugin as a repo string
     py3 repo: str = vim.eval('a:plugin')
@@ -23,7 +41,7 @@ python3 << EOF
 import rustplug
 from rustplug import Environment
 from rustplug import Plugin
-from rustplug import logger  # DEBUG - REMOVE THIS
+from rustplug import logger
 
 
 plugin_name: str = repo.rsplit('/', 1)[-1]

--- a/autoload/rustplug.vim
+++ b/autoload/rustplug.vim
@@ -61,7 +61,10 @@ function! rustplug#run_binary(binary) abort
     let port = 8700
     for i in range(100)
 
-        let job = job_start([a:binary, '--port', port], job_options)
+        let env = environ()
+        let env["VII_PLUGIN_PORT"] = port
+        let job_options["env"] = env
+        let job = job_start([a:binary], job_options)
 
         if job_status(job) == 'fail'
             let port += 1

--- a/autoload/rustplug.vim
+++ b/autoload/rustplug.vim
@@ -56,12 +56,24 @@ function! rustplug#run_binary(binary) abort
         let job_id = 0
         let job_options = {}
     endif
-    let job = job_start([a:binary], job_options)
+
+    " Try ports 8700 - 8799
+    let port = 8700
+    for i in range(100)
+
+        let job = job_start([a:binary, '--port', port], job_options)
+
+        if job_status(job) == 'fail'
+            let port += 1
+        else
+            break
+        endif
+    endfor
 
     " 2. Connect to Server
     " Needs time to wait for server startup
 
-    let ch_address = 'localhost:8765'
+    let ch_address = 'localhost:' . port
     let ch_options = {}
     let channel = ch_open(ch_address, ch_options)
 

--- a/autoload/rustplug.vim
+++ b/autoload/rustplug.vim
@@ -14,7 +14,7 @@ function! rustplug#logerr(message) abort
     "echoerr a:message
 endfunction
 
-function! rustplug#runall(plugin) abort
+function! rustplug#runall(ctx = {}) abort
 python3 << EOF
 """ Run all binaries in our rustplug directory. """
 import rustplug

--- a/autoload/rustplug.vim
+++ b/autoload/rustplug.vim
@@ -64,6 +64,7 @@ function! rustplug#run_binary(binary) abort
         let env = environ()
         let env["VII_PLUGIN_PORT"] = port
         let job_options["env"] = env
+        let job_options["waittime"] = 500 " ms
         let job = job_start([a:binary], job_options)
 
         if job_status(job) == 'fail'

--- a/autoload/rustplug.vim
+++ b/autoload/rustplug.vim
@@ -7,6 +7,13 @@
 "     Vim plugin framework for Rust.
 "
 
+function! rustplug#loginfo(message) abort
+    "echomsg a:message
+endfunction
+function! rustplug#logerr(message) abort
+    "echoerr a:message
+endfunction
+
 function! rustplug#run(plugin) abort
 
     " To keep it simple, keeping plugin as a repo string
@@ -48,7 +55,7 @@ function! rustplug#run_binary(binary) abort
     " 4. Stop (Optional) (Deprecated)
     "
 
-    echomsg "Running Binary: " . a:binary
+    call rustplug#loginfo("Running Binary: " . a:binary)
 
     " Verify Arguments
     call rustplug#verify_binary(a:binary)
@@ -57,10 +64,10 @@ function! rustplug#run_binary(binary) abort
     let port = 8700
     for i in range(100)
 
-        echomsg "Trying port: " . port
+        call rustplug#loginfo("Trying port: " . port)
 
         " 1. Start Server
-        echomsg "Starting Server"
+        call rustplug#loginfo("Starting Server")
 
         let env = environ()
         let env["VII_PLUGIN_PORT"] = port
@@ -69,11 +76,11 @@ function! rustplug#run_binary(binary) abort
         let job = job_start([a:binary], job_options)
 
         if job_status(job) == 'fail'
-            echomsg "Job Failed"
+            call rustplug#loginfo("Job Failed")
             let port += 1
             continue
         else
-            echomsg "Job Succeeded"
+            call rustplug#loginfo("Job Succeeded")
         endif
 
         " 2. Connect to Server
@@ -90,15 +97,15 @@ function! rustplug#run_binary(binary) abort
             " End Job, just in case
             call job_stop(job)
 
-            echomsg "Channel Failed"
+            call rustplug#loginfo("Channel Failed")
             let port += 1
             continue
 
             " Throw Error
-            echoerr "Failed to connect to channel."
+            call rustplug#logerr("Failed to connect to channel.")
             throw "Failed to connect to channel for " . a:binary
         else
-            echomsg "Channel Succeeded"
+            call rustplug#loginfo("Channel Succeeded")
             break
         endif
 
@@ -108,7 +115,7 @@ function! rustplug#run_binary(binary) abort
     "
     " Should have a set timer to run.
 
-    echomsg "Running Server"
+    call rustplug#loginfo("Running Server")
 
     let count_ = 0
     while ch_status(channel) == "open"

--- a/autoload/rustplug.vim
+++ b/autoload/rustplug.vim
@@ -64,8 +64,12 @@ function! rustplug#run_binary(binary) abort
         let env = environ()
         let env["VII_PLUGIN_PORT"] = port
         let job_options["env"] = env
-        let job_options["waittime"] = 500 " ms
         let job = job_start([a:binary], job_options)
+
+        " Wait Time
+        if job_status(job) == 'fail'
+            sleep 50m
+        endif
 
         if job_status(job) == 'fail'
             let port += 1

--- a/doc/rust-plug.txt
+++ b/doc/rust-plug.txt
@@ -2,7 +2,7 @@
 
 A framework for creating Vim plugins in Rust. ~
 
-Version: 0.0.1
+Version: 0.0.5
 
 ====================================================================
 CONTENTS                                                 *rust-plug*

--- a/plugin/plugin.vim
+++ b/plugin/plugin.vim
@@ -19,7 +19,7 @@ let g:loaded_rust_plug = 1
 let g:rustplug_max_work_time = 5
 
 " Public API
-command! RustPlugRunAll call rustplug#runall()
+command! -nargs=? RustPlugRunAll call rustplug#runall(<f-args>)
 command! -nargs=+ RustPlugRun call rustplug#run(<f-args>)
 command! -nargs=+ RustPlugInstall call rustplug#install(<f-args>)
 command! -nargs=+ RustPlugRunBinary call rustplug#run_binary(<f-args>)

--- a/plugin/plugin.vim
+++ b/plugin/plugin.vim
@@ -19,6 +19,10 @@ let g:loaded_rust_plug = 1
 let g:rustplug_max_work_time = 5
 
 " Public API
+command! RustPlugRunAll call rustplug#runall()
 command! -nargs=+ RustPlugRun call rustplug#run(<f-args>)
 command! -nargs=+ RustPlugInstall call rustplug#install(<f-args>)
 command! -nargs=+ RustPlugRunBinary call rustplug#run_binary(<f-args>)
+
+" Run all Rust Plugins
+call rustplug#runall()

--- a/plugin/plugin.vim
+++ b/plugin/plugin.vim
@@ -14,7 +14,8 @@ endif
 let g:loaded_rust_plug = 1
 
 " Config
-let g:rustplug_max_startup_time = 5
+" Deprecated by ch_open's waittime option
+"let g:rustplug_max_startup_time = 5
 let g:rustplug_max_work_time = 5
 
 " Public API

--- a/pythonx/rustplug.py
+++ b/pythonx/rustplug.py
@@ -4,6 +4,7 @@ import logging
 import platform
 import subprocess
 from pathlib import Path
+from typing import Callable
 from typing import Final
 from typing import Iterable
 from typing import Optional
@@ -126,7 +127,10 @@ class Plugin:
         for binary in self.binaries:
             readable: str = binary.as_posix()
             logger.info(f'Running binary (readable): {readable}')
-            vim.command(f'call {RUN_BINARY_VIM_FUNCTION}("{readable}")')
+
+            # vim.command(f'call {RUN_BINARY_VIM_FUNCTION}("{readable}")')
+            run_binary: Callable = vim.bindeval("function('rustplug#run')")
+            run_binary('AceofSpades5757/rust-plug-poc')
 
 
 class Environment:

--- a/pythonx/rustplug.py
+++ b/pythonx/rustplug.py
@@ -133,6 +133,8 @@ class Plugin:
 
 
 class Environment:
+    """ Rust-Plug Vim Plugin Environment """
+
     def __init__(self, plugin_name: str):
 
         logger.info(f'Init Environment - plugin_name={plugin_name}')

--- a/pythonx/rustplug.py
+++ b/pythonx/rustplug.py
@@ -4,7 +4,6 @@ import logging
 import platform
 import subprocess
 from pathlib import Path
-from typing import Callable
 from typing import Final
 from typing import Iterable
 from typing import Optional

--- a/pythonx/rustplug.py
+++ b/pythonx/rustplug.py
@@ -128,9 +128,9 @@ class Plugin:
             readable: str = binary.as_posix()
             logger.info(f'Running binary (readable): {readable}')
 
-            # vim.command(f'call {RUN_BINARY_VIM_FUNCTION}("{readable}")')
-            run_binary: Callable = vim.bindeval("function('rustplug#run')")
-            run_binary('AceofSpades5757/rust-plug-poc')
+            vim.command(f'call {RUN_BINARY_VIM_FUNCTION}("{readable}")')
+            # run_binary: Callable = vim.bindeval("function('rustplug#run')")
+            # run_binary('AceofSpades5757/rust-plug-poc')
 
 
 class Environment:


### PR DESCRIPTION
* Add log functions.
* Add logs.
* Add `rustplug#runall` to run all Rust plugins.
* Fix `run_binary` function to properly start plugin, as job, and connect to it, as channel.
* Bump version in docs. This hasn't been getting updated.
* Comment out `g:rustplug_max_startup_time` for now. It should be reimplemented with the new wait method.
* Add Python documentation.
* Add commented code to use Funcref. This would be more idiomatic with Python/Vim, but caused a recursive error (probably a typo).